### PR TITLE
Fixed a crash when there is no noise database file

### DIFF
--- a/dhvani/src/synthesizer.c
+++ b/dhvani/src/synthesizer.c
@@ -246,11 +246,13 @@ void initialize_pathnames()
 
 	fd = fopen(noisepathname, "r");
 	i = 0;
-	while (fread(&noise[i], sizeof(noise[0]), 1, fd)) {
-		i = i + 1;
-	};
-	fclose(fd);
-
+	
+	if(fd != NULL) {
+		while (fread(&noise[i], sizeof(noise[0]), 1, fd)) {
+			i = i + 1;
+		};
+		fclose(fd);
+	}
 }
 
 /*-----------------------------------------------------------------------


### PR DESCRIPTION
When noise database file is not present running dhvani causes a segmentation fault. This is due to accessing a NULL pointer. Fixed this issue.
